### PR TITLE
upgrade clojure-future-spec to 1.9.0-beta4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,5 +9,5 @@
 
   :dependencies
   [[org.clojure/clojure "1.8.0"]
-   [clojure-future-spec "1.9.0-alpha14"]
+   [clojure-future-spec "1.9.0-beta4"]
    [mvxcvi/multihash "2.0.1"]])

--- a/src/merkledag/ref.clj
+++ b/src/merkledag/ref.clj
@@ -2,7 +2,7 @@
   "Mutable references stored with a repository."
   (:require
     [clojure.future :refer [inst? nat-int?]]
-    [clojure.spec :as s]
+    [clojure.spec.alpha :as s]
     [multihash.core :as multihash])
   (:import
     java.time.Instant


### PR DESCRIPTION
The main thing is to migrate from referring to the old clojure.spec namespace to the new
clojure.spec.alpha namespace.